### PR TITLE
Mirror of nike-inc cerberus-java-client#39

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,8 +24,8 @@ apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish'
 apply plugin: "com.github.johnrengelman.shadow"
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 task copyProjectVersion() {
     def releaseVersion = version

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-version=5.3.1
+version=6.0.0
 groupId=com.nike
 artifactId=cerberus-client

--- a/src/main/java/com/nike/cerberus/client/auth/CerberusCredentialsProvider.java
+++ b/src/main/java/com/nike/cerberus/client/auth/CerberusCredentialsProvider.java
@@ -16,7 +16,16 @@
 
 package com.nike.cerberus.client.auth;
 
-
 public interface CerberusCredentialsProvider {
+
     CerberusCredentials getCredentials();
+
+    /**
+     * Overrideable method to tell a provider chain if a provider should be ran.
+     * @return true if the provider should run.
+     */
+    default boolean shouldRun() {
+        return true;
+    }
+
 }

--- a/src/main/java/com/nike/cerberus/client/auth/CerberusCredentialsProviderChain.java
+++ b/src/main/java/com/nike/cerberus/client/auth/CerberusCredentialsProviderChain.java
@@ -77,6 +77,11 @@ public class CerberusCredentialsProviderChain implements CerberusCredentialsProv
 
         List<String> logMessages = new ArrayList<>();
         for (final CerberusCredentialsProvider credentialsProvider : credentialsProviderList) {
+
+            if (! credentialsProvider.shouldRun()) {
+                continue;
+            }
+
             try {
                 final CerberusCredentials credentials = credentialsProvider.getCredentials();
 

--- a/src/main/java/com/nike/cerberus/client/auth/aws/EcsTaskRoleCerberusCredentialsProvider.java
+++ b/src/main/java/com/nike/cerberus/client/auth/aws/EcsTaskRoleCerberusCredentialsProvider.java
@@ -27,6 +27,7 @@ import com.google.gson.JsonSyntaxException;
 import com.nike.cerberus.client.CerberusClientException;
 import com.nike.cerberus.client.UrlResolver;
 import com.nike.cerberus.client.auth.CerberusCredentialsProvider;
+import com.nike.cerberus.client.util.EnvironmentUtils;
 import okhttp3.OkHttpClient;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -97,6 +98,10 @@ public class EcsTaskRoleCerberusCredentialsProvider extends BaseAwsCredentialsPr
      */
     public EcsTaskRoleCerberusCredentialsProvider(UrlResolver urlResolver, String xCerberusClientOverride) {
         super(urlResolver, xCerberusClientOverride);
+    }
+
+    public boolean shouldRun() {
+        return EnvironmentUtils.isRunningInEcs();
     }
 
     /**

--- a/src/main/java/com/nike/cerberus/client/auth/aws/InstanceRoleCerberusCredentialsProvider.java
+++ b/src/main/java/com/nike/cerberus/client/auth/aws/InstanceRoleCerberusCredentialsProvider.java
@@ -24,6 +24,7 @@ import com.google.gson.JsonSyntaxException;
 import com.nike.cerberus.client.CerberusClientException;
 import com.nike.cerberus.client.UrlResolver;
 import com.nike.cerberus.client.auth.CerberusCredentialsProvider;
+import com.nike.cerberus.client.util.EnvironmentUtils;
 import okhttp3.OkHttpClient;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -86,6 +87,10 @@ public class InstanceRoleCerberusCredentialsProvider extends BaseAwsCredentialsP
      */
     public InstanceRoleCerberusCredentialsProvider(UrlResolver urlResolver, String xCerberusClientOverride) {
         super(urlResolver, xCerberusClientOverride);
+    }
+
+    public boolean shouldRun() {
+        return EnvironmentUtils.isRunningInEc2();
     }
 
     /**

--- a/src/main/java/com/nike/cerberus/client/util/EnvironmentUtils.java
+++ b/src/main/java/com/nike/cerberus/client/util/EnvironmentUtils.java
@@ -1,0 +1,74 @@
+package com.nike.cerberus.client.util;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+/**
+ * Simple Util for determining environment metadata
+ */
+public class EnvironmentUtils {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EnvironmentUtils.class);
+
+    /**
+     * This endpoint is available on EC2 instances
+     */
+    private static final String INSTANCE_IDENTITY_DOCUMENT = "http://169.254.169.254/latest/dynamic/instance-identity/document";
+
+    /**
+     * This endpoint is available on ECS Containers
+     */
+    private static final String ECS_METADATA_ENDPOINT = "http://localhost:51678/v1/metadata";
+
+    private EnvironmentUtils() {
+    }
+
+    /**
+     * True if the current system is running in a pure EC2 environment, and not ECS.
+     */
+    public static boolean isRunningInEc2() {
+        return hasInstanceIdentity() && ! isRunningInEcs();
+    }
+
+    /**
+     * True if the http://169.254.169.254/latest/dynamic/instance-identity/document endpoint
+     * is available and returns a 2xx status code.  True means we are currently running on
+     * an Ec2 instance.  This check should work both on Linux and Windows.
+     */
+    public static boolean hasInstanceIdentity() {
+        return canGetSuccessfully(INSTANCE_IDENTITY_DOCUMENT);
+    }
+
+    /**
+     *
+     * @return true if this is a container in ECS
+     */
+    public static boolean isRunningInEcs() {
+        return canGetSuccessfully(ECS_METADATA_ENDPOINT);
+    }
+
+    protected static boolean canGetSuccessfully(String url) {
+        OkHttpClient httpClient = new OkHttpClient.Builder()
+                .connectTimeout(500, MILLISECONDS)
+                .readTimeout(500, MILLISECONDS)
+                .writeTimeout(500, MILLISECONDS)
+                .build();
+
+        Request request = new Request.Builder().get().url(url).build();
+
+        try (Response response = httpClient.newCall(request).execute()) {
+            if (response.isSuccessful()) {
+                return true;
+            }
+        } catch (Exception e) {
+            LOGGER.debug("Error when trying to GET {}", url, e);
+        }
+        return false;
+    }
+
+}

--- a/src/test/java/com/nike/cerberus/client/auth/CerberusCredentialsProviderChainTest.java
+++ b/src/test/java/com/nike/cerberus/client/auth/CerberusCredentialsProviderChainTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -47,6 +48,8 @@ public class CerberusCredentialsProviderChainTest {
     public void setup() {
         credentialsProviderOne = mock(CerberusCredentialsProvider.class);
         credentialsProviderTwo = mock(CerberusCredentialsProvider.class);
+        when(credentialsProviderOne.shouldRun()).thenReturn(true);
+        when(credentialsProviderTwo.shouldRun()).thenReturn(true);
         credentialsProviderChain = new CerberusCredentialsProviderChain(credentialsProviderOne, credentialsProviderTwo);
     }
 
@@ -124,7 +127,7 @@ public class CerberusCredentialsProviderChainTest {
     }
 
     @Test
-    public void list_contstructor_set_provider_list() {
+    public void list_constructor_set_provider_list() {
         List<CerberusCredentialsProvider> list = new LinkedList<>();
         list.add(credentialsProviderOne);
         list.add(credentialsProviderTwo);
@@ -167,5 +170,17 @@ public class CerberusCredentialsProviderChainTest {
         public String getToken() {
             return TOKEN;
         }
+    }
+
+    @Test
+    public void test_that_if_a_provider_returns_false_for_should_run_it_is_not_ran() {
+        when(credentialsProviderOne.shouldRun()).thenReturn(false);
+        when(credentialsProviderTwo.getCredentials()).thenReturn(new TestCerberusCredentials());
+
+        CerberusCredentials credentials = credentialsProviderChain.getCredentials();
+
+        assertThat(credentials).isNotNull();
+
+        verify(credentialsProviderOne, never()).getCredentials();
     }
 }

--- a/src/test/java/com/nike/cerberus/client/util/EnvironmentUtilsTest.java
+++ b/src/test/java/com/nike/cerberus/client/util/EnvironmentUtilsTest.java
@@ -1,0 +1,22 @@
+package com.nike.cerberus.client.util;
+
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class EnvironmentUtilsTest {
+
+    @Test
+    public void test_that_canGetSuccessfully_can_get_google_index() {
+        assertTrue(EnvironmentUtils.canGetSuccessfully("http://www.google.com"));
+    }
+
+    @Test
+    public void test_that_canGetSuccessfully_can_not_get_random_http_address() {
+        assertFalse(EnvironmentUtils.canGetSuccessfully("http://" + UUID.randomUUID().toString() + ".com/" + UUID.randomUUID().toString()));
+    }
+
+}


### PR DESCRIPTION
Mirror of nike-inc cerberus-java-client#39
[BREAKING CHANGE] Utilizes default method on interface which is a Java 8 specific feature, thus changing source and target to 1.8 from 1.7 and Major rev'd version.

- Provides a hook to allow Credentials Providers to mark themselves as skippable.
